### PR TITLE
Cho phép thay đổi cách đọc phần thập phân

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tất cả lịch sử tiến trình phát triển thư viện
 
+# 1.3.0
+
+- Cho phép thay đổi cách đọc phần thập phân.
+
 # 1.2.1
 
 - Hổ trợ PHP8.

--- a/README.md
+++ b/README.md
@@ -122,16 +122,11 @@ Trong một số loại tiền tệ, bạn cần thay đổi cách đọc theo �
 ```php
 use PHPViet\NumberToWords\Transformer;
 
-$transformer = new Transformer();
-
-// Đặt số chữ số phần thập phân
-$transformer->setDecimalPart(2); 
+// Đặt số chữ số phần thập phân (tham số đầu tiên Dictionary có thể null)
+$transformer = new Transformer(null, 2);
 
 // năm mươi sáu đô chín mươi xen, thay vì năm mươi sáu đô chín xen
 $transformer->toCurrency(56.90);
-
-// Hoặc đơn giản
-$transformer->setDecimalPart(2)->toCurrency(56.90);
 ```
 
 Ngoài ra ta còn có thể sử dụng đơn vị tiền tệ khác thông qua tham trị thứ 2 của phương thức

--- a/README.md
+++ b/README.md
@@ -118,6 +118,21 @@ $transformer->toCurrency(95500200);
 $transformer->toCurrency(854000900);
 
 ```
+Trong một số loại tiền tệ, bạn cần thay đổi cách đọc theo đơn vị quy đổi, ví dụ 1 đô = 100 xen
+```php
+use PHPViet\NumberToWords\Transformer;
+
+$transformer = new Transformer();
+
+// Đặt số chữ số phần thập phân
+$transformer->setDecimalPart(2); 
+
+// năm mươi sáu đô chín mươi xen, thay vì năm mươi sáu đô chín xen
+$transformer->toCurrency(56.90);
+
+// Hoặc đơn giản
+$transformer->setDecimalPart(2)->toCurrency(56.90);
+```
 
 Ngoài ra ta còn có thể sử dụng đơn vị tiền tệ khác thông qua tham trị thứ 2 của phương thức
 `toCurrency`, với mảng phần từ đầu tiên là đơn vị cho số nguyên và kế tiếp là đơn vị của phân số:

--- a/src/Concerns/NumberResolver.php
+++ b/src/Concerns/NumberResolver.php
@@ -22,18 +22,18 @@ trait NumberResolver
      * @return array
      * @throws InvalidArgumentException
      */
-    protected function resolveNumber($number, $decimalPart = null): array
+    protected function resolveNumber($number): array
     {
         if (! is_numeric($number)) {
             throw new InvalidArgumentException(sprintf('Number arg (`%s`) must be numeric!', $number));
         }
 
 
-        if ($decimalPart === null) {
+        if ($this->decimalPart === null) {
             $number += 0; // trick xóa các số 0 lẻ sau cùng của phân số đối với input là chuỗi.
             $number = (string) $number;
         } else {
-            $number = number_format($number, $decimalPart, '.', '');
+            $number = number_format($number, $this->decimalPart, '.', '');
         }
         $minus = '-' === $number[0];
 

--- a/src/Concerns/NumberResolver.php
+++ b/src/Concerns/NumberResolver.php
@@ -22,14 +22,19 @@ trait NumberResolver
      * @return array
      * @throws InvalidArgumentException
      */
-    protected function resolveNumber($number): array
+    protected function resolveNumber($number, $decimal_part = -1): array
     {
         if (! is_numeric($number)) {
             throw new InvalidArgumentException(sprintf('Number arg (`%s`) must be numeric!', $number));
         }
 
-        $number += 0; // trick xóa các số 0 lẻ sau cùng của phân số đối với input là chuỗi.
-        $number = (string) $number;
+
+        if($decimal_part === -1) {
+            $number += 0; // trick xóa các số 0 lẻ sau cùng của phân số đối với input là chuỗi.
+            $number = (string) $number;
+        } else {
+            $number = number_format($number, $decimal_part, ".", "");
+        }
         $minus = '-' === $number[0];
 
         if (false !== strpos($number, '.')) {

--- a/src/Concerns/NumberResolver.php
+++ b/src/Concerns/NumberResolver.php
@@ -22,18 +22,18 @@ trait NumberResolver
      * @return array
      * @throws InvalidArgumentException
      */
-    protected function resolveNumber($number, $decimal_part = -1): array
+    protected function resolveNumber($number, $decimalPart = null): array
     {
         if (! is_numeric($number)) {
             throw new InvalidArgumentException(sprintf('Number arg (`%s`) must be numeric!', $number));
         }
 
 
-        if($decimal_part === -1) {
+        if ($decimalPart === null) {
             $number += 0; // trick xóa các số 0 lẻ sau cùng của phân số đối với input là chuỗi.
             $number = (string) $number;
         } else {
-            $number = number_format($number, $decimal_part, ".", "");
+            $number = number_format($number, $decimalPart, '.', '');
         }
         $minus = '-' === $number[0];
 

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -19,9 +19,20 @@ class Transformer
     use Concerns\TripletTransformer;
 
     /**
+     * @const int
+     */
+    const DEFAULT_DECIMAL_PART = -1;
+
+    /**
      * @var DictionaryInterface
      */
     protected $dictionary;
+
+    /**
+     * Mặc định bỏ số các số 0 sau phần thập phân
+     * @var int
+     */
+    protected $decimal_part = self::DEFAULT_DECIMAL_PART;
 
     /**
      * Tạo đối tượng mới với từ điển chỉ định.
@@ -46,7 +57,7 @@ class Transformer
      */
     public function toWords($number): string
     {
-        [$minus, $number, $decimal] = $this->resolveNumber($number);
+        [$minus, $number, $decimal] = $this->resolveNumber($number, $this->decimal_part);
         $words[] = $minus ? $this->dictionary->minus() : '';
 
         if (0 === $number) {
@@ -81,7 +92,7 @@ class Transformer
     {
         $unit = (array) $unit;
         $originNumber = $number;
-        [$minus, $number, $decimal] = $this->resolveNumber($number);
+        [$minus, $number, $decimal] = $this->resolveNumber($number, $this->decimal_part);
 
         if (0 === $decimal || ! isset($unit[1])) {
             $words[] = $this->toWords($originNumber);
@@ -96,5 +107,12 @@ class Transformer
         }
 
         return $this->collapseWords($words);
+    }
+
+    public function setDecimalPart($decimal_part)
+    {
+        $this->decimal_part = $decimal_part;
+
+        return $this;
     }
 }

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -19,33 +19,29 @@ class Transformer
     use Concerns\TripletTransformer;
 
     /**
-     * @const int
-     */
-    const DEFAULT_DECIMAL_PART = -1;
-
-    /**
      * @var DictionaryInterface
      */
     protected $dictionary;
 
     /**
-     * Mặc định bỏ số các số 0 sau phần thập phân
+     * Mặc định bỏ số các số 0 sau phần thập phân.
      * @var int
      */
-    protected $decimal_part = self::DEFAULT_DECIMAL_PART;
+    protected $decimalPart;
 
     /**
-     * Tạo đối tượng mới với từ điển chỉ định.
+     * Tạo đối tượng mới với từ điển chỉ định và phần thập phân.
      *
      * @param  DictionaryInterface  $dictionary
      */
-    public function __construct(?DictionaryInterface $dictionary = null)
+    public function __construct(?DictionaryInterface $dictionary = null, $decimalPart = null)
     {
         if (null === $dictionary) {
             $dictionary = new Dictionary();
         }
 
         $this->dictionary = $dictionary;
+        $this->decimalPart = $decimalPart;
     }
 
     /**
@@ -57,7 +53,7 @@ class Transformer
      */
     public function toWords($number): string
     {
-        [$minus, $number, $decimal] = $this->resolveNumber($number, $this->decimal_part);
+        [$minus, $number, $decimal] = $this->resolveNumber($number, $this->decimalPart);
         $words[] = $minus ? $this->dictionary->minus() : '';
 
         if (0 === $number) {
@@ -92,7 +88,7 @@ class Transformer
     {
         $unit = (array) $unit;
         $originNumber = $number;
-        [$minus, $number, $decimal] = $this->resolveNumber($number, $this->decimal_part);
+        [$minus, $number, $decimal] = $this->resolveNumber($number, $this->decimalPart);
 
         if (0 === $decimal || ! isset($unit[1])) {
             $words[] = $this->toWords($originNumber);
@@ -107,12 +103,5 @@ class Transformer
         }
 
         return $this->collapseWords($words);
-    }
-
-    public function setDecimalPart($decimal_part)
-    {
-        $this->decimal_part = $decimal_part;
-
-        return $this;
     }
 }

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -53,7 +53,7 @@ class Transformer
      */
     public function toWords($number): string
     {
-        [$minus, $number, $decimal] = $this->resolveNumber($number, $this->decimalPart);
+        [$minus, $number, $decimal] = $this->resolveNumber($number);
         $words[] = $minus ? $this->dictionary->minus() : '';
 
         if (0 === $number) {
@@ -88,7 +88,7 @@ class Transformer
     {
         $unit = (array) $unit;
         $originNumber = $number;
-        [$minus, $number, $decimal] = $this->resolveNumber($number, $this->decimalPart);
+        [$minus, $number, $decimal] = $this->resolveNumber($number);
 
         if (0 === $decimal || ! isset($unit[1])) {
             $words[] = $this->toWords($originNumber);

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -7,6 +7,8 @@
 
 namespace PHPViet\NumberToWords\Tests;
 
+use PHPViet\NumberToWords\Transformer;
+
 /**
  * @author Vuong Minh <vuongxuongminh@gmail.com>
  * @since 1.0.0
@@ -34,7 +36,9 @@ class CurrencyTest extends TestCase
      */
     public function testUSDSetDecimalPart($expect, $float, $decimal_part)
     {
-        $this->assertEquals($expect, $this->transformer->setDecimalPart($decimal_part)->toCurrency($float, ['đô', 'xen']));
+        $transformer =  new Transformer($this->dictionary, $decimal_part);
+
+        $this->assertEquals($expect, $transformer->toCurrency($float, ['đô', 'xen']));
     }
 
     public function usdDecimalPartDataProvider(): array
@@ -60,7 +64,8 @@ class CurrencyTest extends TestCase
      */
     public function testSetDecimalPart($expect, $float, $decimal_part)
     {
-        $this->assertEquals($expect, $this->transformer->setDecimalPart($decimal_part)->toCurrency($float));
+        $transformer =  new Transformer($this->dictionary, $decimal_part);
+        $this->assertEquals($expect, $transformer->toCurrency($float));
     }
 
     public function decimalPartDataProvider(): array

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -34,9 +34,9 @@ class CurrencyTest extends TestCase
     /**
      * @dataProvider usdDecimalPartDataProvider
      */
-    public function testUSDSetDecimalPart($expect, $float, $decimal_part)
+    public function testUSDSetDecimalPart($expect, $float, $decimalPart)
     {
-        $transformer =  new Transformer($this->dictionary, $decimal_part);
+        $transformer =  new Transformer($this->dictionary, $decimalPart);
 
         $this->assertEquals($expect, $transformer->toCurrency($float, ['đô', 'xen']));
     }
@@ -62,9 +62,9 @@ class CurrencyTest extends TestCase
     /**
      * @dataProvider decimalPartDataProvider
      */
-    public function testSetDecimalPart($expect, $float, $decimal_part)
+    public function testSetDecimalPart($expect, $float, $decimalPart)
     {
-        $transformer =  new Transformer($this->dictionary, $decimal_part);
+        $transformer =  new Transformer($this->dictionary, $decimalPart);
         $this->assertEquals($expect, $transformer->toCurrency($float));
     }
 

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -29,6 +29,58 @@ class CurrencyTest extends TestCase
         $this->assertEquals($expect, $this->transformer->toCurrency($number, ['đô', 'xen']));
     }
 
+    /**
+     * @dataProvider usdDecimalPartDataProvider
+     */
+    public function testUSDSetDecimalPart($expect, $float, $decimal_part)
+    {
+        $this->assertEquals($expect, $this->transformer->setDecimalPart($decimal_part)->toCurrency($float, ['đô', 'xen']));
+    }
+
+    public function usdDecimalPartDataProvider(): array
+    {
+        return [
+            ['không đô', 0, 1],
+            ['một nghìn đô', 1000, 2],
+            ['một nghìn không trăm linh một đô', 1001, 3],
+            ['một nghìn không trăm linh hai đô', 1002, 4],
+            ['âm không đô mười xen', -0.1, 2],
+            ['âm chín mươi chín đô', -99, 3],
+            ['âm chín mươi tám đô', -98, 4],
+            ['không đô ba trăm bảy mươi chín xen', 0.378758, 3],
+            ['không đô chín mươi hai xen', 0.922174, 2],
+            ['năm trăm bảy mươi ba đô năm mươi tám xen', 573.58, 2],
+            ['sáu trăm sáu mươi chín đô mười bốn xen', 669.135, 2],
+            ['ba trăm chín mươi lăm đô mười bốn xen', 395.136, 2],
+        ];
+    }
+
+    /**
+     * @dataProvider decimalPartDataProvider
+     */
+    public function testSetDecimalPart($expect, $float, $decimal_part)
+    {
+        $this->assertEquals($expect, $this->transformer->setDecimalPart($decimal_part)->toCurrency($float));
+    }
+
+    public function decimalPartDataProvider(): array
+    {
+        return [
+            ['không đồng', 0, 1],
+            ['một nghìn đồng', 1000, 2],
+            ['một nghìn không trăm linh một đồng', 1001, 3],
+            ['một nghìn không trăm linh hai đồng', 1002, 4],
+            ['âm không phẩy mười đồng', -0.1, 2],
+            ['âm chín mươi chín đồng', -99, 3],
+            ['âm chín mươi tám đồng', -98, 4],
+            ['không phẩy ba trăm bảy mươi chín đồng', 0.378758, 3],
+            ['không phẩy chín mươi hai đồng', 0.922174, 2],
+            ['năm trăm bảy mươi ba phẩy năm mươi tám đồng', 573.58, 2],
+            ['sáu trăm sáu mươi chín phẩy mười bốn đồng', 669.135, 2],
+            ['ba trăm chín mươi lăm phẩy mười bốn đồng', 395.136, 2],
+        ];
+    }
+
     public function usdDataProvider(): array
     {
         return [

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -37,6 +37,32 @@ class NumberTest extends TestCase
         $this->assertEquals($expect, $this->transformer->toWords($float));
     }
 
+    /**
+     * @dataProvider decimalPartDataProvider
+     */
+    public function testSetDecimalPart($expect, $float, $decimal_part)
+    {
+        $this->assertEquals($expect, $this->transformer->setDecimalPart($decimal_part)->toWords($float));
+    }
+
+    public function decimalPartDataProvider(): array
+    {
+        return [
+            ['không', 0, 1],
+            ['một nghìn', 1000, 2],
+            ['một nghìn không trăm linh một', 1001, 3],
+            ['một nghìn không trăm linh hai', 1002, 4],
+            ['âm không phẩy mười', -0.1, 2],
+            ['âm chín mươi chín', -99, 3],
+            ['âm chín mươi tám', -98, 4],
+            ['không phẩy ba trăm bảy mươi chín', 0.378758, 3],
+            ['không phẩy chín mươi hai', 0.922174, 2],
+            ['năm trăm bảy mươi ba phẩy năm mươi tám', 573.58, 2],
+            ['sáu trăm sáu mươi chín phẩy mười bốn', 669.135, 2],
+            ['ba trăm chín mươi lăm phẩy mười bốn', 395.136, 2],
+        ];
+    }
+
     public function fractionDataProvider(): array
     {
         return [

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -42,9 +42,9 @@ class NumberTest extends TestCase
     /**
      * @dataProvider decimalPartDataProvider
      */
-    public function testSetDecimalPart($expect, $float, $decimal_part)
+    public function testSetDecimalPart($expect, $float, $decimalPart)
     {
-        $transformer =  new Transformer($this->dictionary, $decimal_part);
+        $transformer =  new Transformer($this->dictionary, $decimalPart);
 
         $this->assertEquals($expect, $transformer->toWords($float));
     }

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -7,6 +7,8 @@
 
 namespace PHPViet\NumberToWords\Tests;
 
+use PHPViet\NumberToWords\Transformer;
+
 /**
  * @author Vuong Minh <vuongxuongminh@gmail.com>
  * @since 1.0.0
@@ -42,7 +44,9 @@ class NumberTest extends TestCase
      */
     public function testSetDecimalPart($expect, $float, $decimal_part)
     {
-        $this->assertEquals($expect, $this->transformer->setDecimalPart($decimal_part)->toWords($float));
+        $transformer =  new Transformer($this->dictionary, $decimal_part);
+
+        $this->assertEquals($expect, $transformer->toWords($float));
     }
 
     public function decimalPartDataProvider(): array


### PR DESCRIPTION
## What
Cho phép người dùng thay đổi cách đọc phần thập phân bằng cách sử dụng method `setDecimalPart`
```php
$transformer->setDecimalPart(2); 
$transformer->toCurrency(56.90);

// Hoặc đơn giản
$transformer->setDecimalPart(2)->toCurrency(56.90);
```
++ năm mươi sáu đô <ins>chín mươi</ins> xen

## Why
Trong một số loại tiền tên, tiền lẻ được sử dụng một đơn vị riêng với cố định một cách quy đổi, ví dụ 1 USD = 100 cent 

Ví dụ số $56.90 sẽ đọc là "năm mươi sáu đô chín **mươi** xen" thay vì "năm mươi sáu đô chín ~~mươi~~ xen"

## How 
Chức năng này tắt theo mặc định khi `$decimal_part = -1`. Phương thức `setDecimalPart` cho phép đặt giá trị cho nó.

Nếu  `$decimal_part` khác `-1` (mặc định) thì sử dụng hàm [`number_format`](https://www.php.net/manual/en/function.number-format.php) của PHP để format chuỗi số nhập vào thay vì xoá các số 0 lẻ sau cùng

```php
if($decimal_part === -1) {
    $number += 0; // trick xóa các số 0 lẻ sau cùng của phân số đối với input là chuỗi.
    $number = (string) $number;
} else {
    $number = number_format($number, $decimal_part, ".", "");
}
```

## Changes details
- Thêm attribute `$decimal_part` và method `setDecimalPart`  vào class `src/Transformer.php`
- Thêm mã xử lý `number_format` ở trên vào class `src/Concerns/NumberResolver.php`
- Thêm unit test cho các trường hợp có `setDecimalPart` vào `tests/CurrencyTest.php` và `tests/NumberTest.php`
- Cập nhật README.md hướng dẫn cho `setDecimalPart` 